### PR TITLE
Support liquid 5.4.0 in order to support ruby 3.2

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -64,7 +64,6 @@ module Jekyll
 
     def info
       {
-        :registers => context.registers,
         :filters   => [Jekyll::Filters],
       }
     end


### PR DESCRIPTION
The following errors is raised when jekyll-seo-tag is used with liquid-5.4.0. This is caused by the fact that context.registers no longer returns Hash, but Liquid::Registers.

Addressing:
```
/opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:176:in `render': undefined method `each' for #<Liquid::Registers:0x00007f2b142ddfc0>

        options[:registers]&.each do |key, register|
                           ^^^^^^
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:204:in `render!'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/jekyll-seo-tag-2.8.0/lib/jekyll-seo-tag.rb:36:in `render'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/tag.rb:51:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:80:in `render_node'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:230:in `render_node'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/block_body.rb:213:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/document.rb:41:in `render_to_output_buffer'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:194:in `render'
	from /opt/hostedtoolcache/Ruby/3.1.2/x64/lib/ruby/gems/3.1.0/gems/liquid-5.4.0/lib/liquid/template.rb:204:in `render!'
```

Related to: https://github.com/jekyll/jekyll/pull/9229